### PR TITLE
Run Playwright tests against full stack with optional live API

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
@@ -15,6 +16,7 @@
     "recharts": "^3.5.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
     "typescript": "~5.8.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'retain-on-failure',
+    headless: true,
+  },
+  webServer: {
+    command:
+      'cd .. && npx concurrently "npm run dev --prefix frontend -- --host --port 4173" "cd backend && python -m uvicorn app.main:app --reload"',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/tests/README.md
+++ b/frontend/tests/README.md
@@ -1,0 +1,15 @@
+# Playwright integration tests
+
+These tests run against the repo-level dev stack (`npm run dev --prefix ..`), which launches both the Vite frontend (port `4173` in CI) and the FastAPI backend. By default, the browser requests are intercepted with mocks instead of calling the real backend API so the suite stays deterministic. The mocks intentionally mirror the personas and refund scenarios defined in `backend/scripts/seed_story.py` so that UI expectations stay aligned with the seeded demo data.
+
+- `fixtures/seedStoryData.ts` contains the refund-focused project, traces, and logs that mirror the seed script story beats.
+- `fixtures/mockApi.ts` wires Playwright `page.route` handlers to return the seed data for `/projects`, `/traces`, `/views`, and `/aql/query` requests.
+- Tests live alongside the fixtures in this folder and can be extended by adding more seed data or route handlers.
+
+Run the suite with:
+
+```
+npm run test:e2e --prefix frontend
+```
+
+To exercise the real API responses instead of mocks, start the suite with `E2E_USE_LIVE_API=1`—the web server will still boot the backend so either path works.

--- a/frontend/tests/fixtures/mockApi.ts
+++ b/frontend/tests/fixtures/mockApi.ts
@@ -1,0 +1,76 @@
+import { API_BASE_URL } from '../../src/services/api';
+import { seedLogs, seedProject, seedQueries, seedTraces, seedViews, childCounts } from './seedStoryData';
+import type { AqlFilter } from '../../src/types';
+import type { Page, Route } from '@playwright/test';
+
+const useLiveApi = process.env.E2E_USE_LIVE_API === 'true' || process.env.E2E_USE_LIVE_API === '1';
+
+const respondJson = (route: Route, payload: unknown, status = 200) =>
+  route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(payload) });
+
+const matchesFilter = (value: unknown, filter: AqlFilter): boolean => {
+  if (filter.op === '=' || filter.op === '==') {
+    return String(value ?? '').toLowerCase() === String(filter.value ?? '').toLowerCase();
+  }
+  if (filter.op === 'contains') {
+    return String(value ?? '').toLowerCase().includes(String(filter.value ?? '').toLowerCase());
+  }
+  if (filter.op === 'in' && Array.isArray(filter.value)) {
+    return filter.value.map(String).includes(String(value));
+  }
+  return true;
+};
+
+const filterLogs = (filters: AqlFilter[] = []) => {
+  return seedLogs.filter((log) =>
+    filters.every((filter) => {
+      const logValue = (log as Record<string, unknown>)[filter.field];
+      return matchesFilter(logValue, filter);
+    }),
+  );
+};
+
+export const mockSeedStoryApi = async (page: Page) => {
+  if (useLiveApi) return;
+
+  await page.route(`${API_BASE_URL}/projects`, (route) => respondJson(route, [seedProject]));
+  await page.route(`${API_BASE_URL}/projects/${seedProject.id}`, (route) => respondJson(route, seedProject));
+  await page.route(new RegExp(`${API_BASE_URL}/projects/${seedProject.id}/traces.*`), (route) => respondJson(route, seedTraces));
+  await page.route(`${API_BASE_URL}/views/${seedProject.id}`, (route) => respondJson(route, seedViews));
+
+  await page.route(`${API_BASE_URL}/aql/query`, async (route) => {
+    const body = await route.request().postDataJSON();
+    const builder = body?.builder;
+
+    if (builder?.shape === 'project_logs') {
+      const filteredLogs = filterLogs(builder.filters || []);
+      return respondJson(route, {
+        shape: 'project_logs',
+        schema: [],
+        data: filteredLogs,
+        query: seedQueries.logs,
+      });
+    }
+
+    if (builder?.shape === 'project_traces') {
+      if (builder.select?.includes('id')) {
+        const idsFilter = (builder.filters || []).find((f: AqlFilter) => f.field === 'id');
+        const ids = Array.isArray(idsFilter?.value) ? idsFilter?.value : builder.filters?.map((f: AqlFilter) => f.value);
+        const data = seedTraces
+          .filter((trace) => !ids || ids.includes(trace.id))
+          .map((trace) => ({ id: trace.id, parent_trace_id: trace.parent_trace_id }));
+        return respondJson(route, { shape: 'project_traces', schema: ['id', 'parent_trace_id'], data });
+      }
+
+      if (builder.dimensions?.includes('parent_trace_id')) {
+        return respondJson(route, {
+          shape: 'project_traces',
+          schema: ['parent_trace_id', 'child_count'],
+          data: childCounts,
+        });
+      }
+    }
+
+    return respondJson(route, { shape: builder?.shape || 'unknown', schema: [], data: [] });
+  });
+};

--- a/frontend/tests/fixtures/seedStoryData.ts
+++ b/frontend/tests/fixtures/seedStoryData.ts
@@ -1,0 +1,129 @@
+import { Log, Project, Span, SpanType, Trace } from '../../src/types';
+
+const now = Date.now();
+
+export const seedProject: Project = {
+  id: 'proj_support',
+  name: 'Refund Issues',
+  org_id: 'org_octoworks',
+};
+
+const makeSpan = (overrides: Partial<Span>): Span => ({
+  id: 'span_refund_root',
+  trace_id: 'trace_refund_incident',
+  parent_id: null,
+  name: 'Support: Refund - Duplicate charge resolved [TCK-88421]',
+  type: SpanType.LLM,
+  start_time: now - 15 * 60 * 1000,
+  end_time: now - 15 * 60 * 1000 + 620,
+  status: 'success',
+  input: { query: 'Customer charged twice for seat add-on' },
+  output: { content: 'Apologized and issued refund per Section 4.1' },
+  metrics: { latency_ms: 620, total_tokens: 1280, cost: 0.00052 },
+  attributes: { model: 'gpt-4o-mini', provider: 'openai' },
+  tags: ['support', 'refund', 'guardrail'],
+  ...overrides,
+});
+
+const incidentSpan = makeSpan({});
+const followupSpan = makeSpan({
+  id: 'span_refund_followup',
+  trace_id: 'trace_refund_followup',
+  name: 'Support: Refund - Late cancellation (escalated) [TCK-88502]',
+  status: 'error',
+  metrics: { latency_ms: 880, total_tokens: 1740, cost: 0.0009 },
+  tags: ['support', 'refund', 'compliance'],
+});
+
+export const seedTraces: Trace[] = [
+  {
+    id: 'trace_refund_incident',
+    project_id: seedProject.id,
+    parent_trace_id: null,
+    trace_group_id: 'trace_group_refund',
+    input_span_id: incidentSpan.id,
+    output_span_id: incidentSpan.id,
+    timestamp: incidentSpan.start_time,
+    total_latency: incidentSpan.metrics.latency_ms,
+    total_cost: incidentSpan.metrics.cost ?? 0,
+    total_tokens: incidentSpan.metrics.total_tokens ?? 0,
+    status: 'success',
+    tags: ['support', 'refund'],
+    root_span: incidentSpan,
+    spans: [incidentSpan],
+  },
+  {
+    id: 'trace_refund_followup',
+    project_id: seedProject.id,
+    parent_trace_id: 'trace_refund_incident',
+    trace_group_id: 'trace_group_refund',
+    input_span_id: followupSpan.id,
+    output_span_id: followupSpan.id,
+    timestamp: followupSpan.start_time,
+    total_latency: followupSpan.metrics.latency_ms,
+    total_cost: followupSpan.metrics.cost ?? 0,
+    total_tokens: followupSpan.metrics.total_tokens ?? 0,
+    status: 'error',
+    tags: ['support', 'refund', 'escalation'],
+    root_span: followupSpan,
+    spans: [followupSpan],
+  },
+];
+
+const baseLog = (overrides: Partial<Log>): Log => ({
+  id: 'log_refund_duplicate',
+  project_id: seedProject.id,
+  trace_id: 'trace_refund_incident',
+  span_id: incidentSpan.id,
+  event_type: 'guardrail',
+  status: 'success',
+  message: 'Support: Refund - Duplicate charge resolved [TCK-88421]',
+  timestamp: incidentSpan.start_time,
+  latency_ms: incidentSpan.metrics.latency_ms,
+  prompt_tokens: 640,
+  completion_tokens: 640,
+  total_tokens: incidentSpan.metrics.total_tokens,
+  cost: incidentSpan.metrics.cost,
+  model: incidentSpan.attributes.model,
+  provider: incidentSpan.attributes.provider,
+  attributes: { ...incidentSpan.attributes },
+  log_metadata: { customer: 'Nexus Technologies' },
+  created_at: incidentSpan.start_time,
+  ...overrides,
+});
+
+export const seedLogs: Log[] = [
+  baseLog({}),
+  baseLog({
+    id: 'log_refund_escalation',
+    trace_id: 'trace_refund_followup',
+    span_id: followupSpan.id,
+    event_type: 'compliance',
+    status: 'error',
+    message: 'Support: Refund - Late cancellation (escalated) [TCK-88502]',
+    timestamp: followupSpan.start_time,
+    latency_ms: followupSpan.metrics.latency_ms,
+    prompt_tokens: 870,
+    completion_tokens: 870,
+    total_tokens: followupSpan.metrics.total_tokens,
+    cost: followupSpan.metrics.cost,
+    log_metadata: { customer: 'Nexus Technologies', policy: 'policy_refunds_v3' },
+  }),
+];
+
+export const seedViews = [
+  {
+    id: 'view_refund_errors',
+    project_id: seedProject.id,
+    name: 'Support Refund Errors',
+    entity_type: 'logs',
+    config: { filters: [{ field: 'status', op: '=', value: 'error' }] },
+    created_at: now,
+  },
+];
+
+export const seedQueries = {
+  logs: `from project_logs(project_id="${seedProject.id}") select id, trace_id, status, event_type, message, latency_ms, total_tokens, cost, timestamp sort timestamp desc limit 200`,
+};
+
+export const childCounts = [{ parent_trace_id: 'trace_refund_incident', child_count: 1 }];

--- a/frontend/tests/logs.seed-story.spec.ts
+++ b/frontend/tests/logs.seed-story.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@playwright/test';
+import { mockSeedStoryApi } from './fixtures/mockApi';
+import { seedLogs, seedProject } from './fixtures/seedStoryData';
+
+test.beforeEach(async ({ page }) => {
+  await mockSeedStoryApi(page);
+});
+
+test('renders refund incident logs from the seed story mocks', async ({ page }) => {
+  await page.goto('/#/logs');
+
+  await expect(page.getByText(seedLogs[0].message)).toBeVisible();
+  await expect(page.getByText(seedLogs[1].message)).toBeVisible();
+
+  await expect(page.locator('span').filter({ hasText: /guardrail/i }).first()).toBeVisible();
+  await expect(page.locator('span').filter({ hasText: /compliance/i }).first()).toBeVisible();
+
+  await expect(page.locator('span').filter({ hasText: /^SUCCESS$/ })).toBeVisible();
+  await expect(page.locator('span').filter({ hasText: /^ERROR$/ })).toBeVisible();
+
+  await expect(page.getByText('Parent 1')).toBeVisible();
+  await expect(page.locator('span').filter({ hasText: /^Child$/ }).first()).toBeVisible();
+});
+
+test('applies the quick error filter to show only escalated refund traces', async ({ page }) => {
+  await page.goto('/#/logs');
+
+  await page.getByRole('button', { name: 'Errors' }).click();
+
+  await expect(page.getByText(seedLogs[1].message)).toBeVisible();
+  await expect(page.getByText(seedLogs[0].message)).not.toBeVisible();
+});


### PR DESCRIPTION
## Summary
- start Playwright's web server with the repo dev stack so backend and frontend boot together on port 4173
- document the shared-stack setup and note the E2E_USE_LIVE_API toggle for hitting real backend responses
- keep seed-story mocks as the default path for deterministic log/traces coverage

## Testing
- npm run test:e2e --prefix frontend

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b329918a08330bb6a1258246ec681)